### PR TITLE
client: update porkbun api hostname to `api.porkbun.com`

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -30,7 +30,7 @@ func New(APIKey, SecretAPIKey string) Client {
 		},
 		baseURL: &url.URL{
 			Scheme: "https",
-			Host:   "porkbun.com",
+			Host:   "api.porkbun.com",
 			Path:   "/api/json/v3",
 		},
 		httpClient: &http.Client{


### PR DESCRIPTION
This patch configure the SDK to use the new Porkbun API hostname `api.porkbun.com`. See the [Porkbun API documentation](https://porkbun.com/api/json/v3/documentation#apiHost) for more details.